### PR TITLE
SW-#4 - implement spi in pal

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: Microsoft
+IndentWidth: 4
+ColumnLimit: 100
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+duo-buildroot-sdk/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
 build/
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+#clangd
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,19 @@ include_directories(/opt/riscv64-linux-headers/include)
 add_executable(Miles ${SOURCES})
 
 if(USE_SPIDEV)
-  target_compile_definitions(Miles PRIVATE USE_SPIDEV)
+  target_compile_definitions(Miles PUBLIC USE_SPIDEV)
+endif()
+
+# Debug mode
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_compile_definitions(Miles PUBLIC DEBUG_ENABLED)
 endif()
 
 # Enable testing
 if(ENABLE_TESTING)
-  enable_testing()
+  MESSAGE(STATUS "Tests are enabled")
+  # enable_testing() # Adds tests to run on host after the build here
   add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.10)
+project(Miles)
+
+# ========== SPI ==========
+option(USE_SPIDEV "Use spidev for spi communication" ON)
+
+# ========== TESTS ==========
+option(ENABLE_TESTING "Enable compilation of tests" ON)
+
+# Set the C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# ========== CMake ==========
+
+MESSAGE(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
+MESSAGE(STATUS "Using compiler: ${CMAKE_C_COMPILER}")
+
+# Define sources and headers
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+file(GLOB_RECURSE HEADERS "include/*.h")
+
+# Add include directories
+include_directories(include)
+include_directories(/opt/riscv64-linux-headers/include)
+
+# Add executable
+add_executable(Miles ${SOURCES})
+
+if(USE_SPIDEV)
+  target_compile_definitions(Miles PRIVATE USE_SPIDEV)
+endif()
+
+# Enable testing
+if(ENABLE_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# Use an official Ubuntu as a parent image
+FROM ubuntu:22.04
+
+# Set environment variables for non-interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required dependencies
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    autotools-dev \
+    bc \
+    bison \
+    build-essential \
+    cmake \
+    cmake-curses-gui \
+    curl \
+    flex \
+    gawk \
+    git \
+    gperf \
+    libexpat-dev \
+    libgmp-dev \
+    libglib2.0-dev \
+    libmpc-dev \
+    libmpfr-dev \
+    libslirp-dev \
+    libtool \
+    ninja-build \
+    patchutils \
+    python3 \
+    python3-pip \
+    rsync \
+    texinfo \
+    wget \
+    zlib1g-dev
+
+# =========================== RISC-V Toolchain ===========================
+# Clone the RISC-V GNU Toolchain repository
+# RUN git clone https://github.com/riscv/riscv-gnu-toolchain /opt/riscv-gnu-toolchain
+
+# Build the RISC-V toolchain for RV64 for linux targets
+# WORKDIR /opt/riscv-gnu-toolchain
+# RUN ./configure --prefix=/opt/riscv
+# RUN make musl -j$(nproc)
+
+# =========================== Milk-V SDK ===========================
+RUN git clone https://github.com/milkv-duo/duo-sdk.git /opt/riscv/
+
+# Add the toolchain to the PATH
+ENV PATH=/opt/riscv/riscv64-linux-musl-x86_64/bin:$PATH
+
+# =========================== RISC-V Linux Headers ===========================
+RUN git clone https://github.com/torvalds/linux.git /opt/linux
+
+WORKDIR /opt/linux
+
+RUN make ARCH=riscv defconfig
+RUN make ARCH=riscv headers_install INSTALL_HDR_PATH=/opt/riscv64-linux-headers/
+
+# =========================== Project Sync ===========================
+
+# Copy the project into the Docker image
+COPY . /opt/miles
+
+# Set the working directory to your project
+WORKDIR /opt/miles
+
+# Copy the build script into the Docker image
+COPY build_project.sh /usr/local/bin/build_project.sh
+RUN chmod +x /usr/local/bin/build_project.sh
+
+# Set the entrypoint to a shell, allows for running commands if needed
+ENTRYPOINT ["/bin/bash"]
+

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@
 
 # Variables
 BOARD := milkv-duo
+ARCH := riscv64
+TOOLCHAIN := c906fdv-riscv64-unknown-linux-musl
 IMAGE_TYPE := sd
 BUILD_DIR := $(PWD)/build
 OS_BUILD_DIR := $(BUILD_DIR)/os
 SW_BUILD_DIR := $(BUILD_DIR)/sw
 OS_DOCKER_IMAGE := milkvtech/milkv-duo:latest
-SOFTWARE_DOCKER_IMAGE := miles-robot-software:latest
+SOFTWARE_DOCKER_IMAGE := miles-sw-build
 BUILDROOT_CONTAINER_NAME := miles-milkv-duo-buildroot
 
 # Targets
@@ -28,14 +30,26 @@ os:
 	@rsync -av --ignore-existing $(PWD)/duo-buildroot-sdk/out $(OS_BUILD_DIR)
 	@docker stop $(BUILDROOT_CONTAINER_NAME)
 
+buildenv-container:
+	@echo "Building buildenv container"
+	@docker build -t $(SOFTWARE_DOCKER_IMAGE) -f ./Dockerfile .
+
+# You need to manually go into the build folder and run ccmake due to issue with ncurses and docker
+configure: buildenv-container
+	@echo "Opening Configuration"
+	@docker run -it $(SOFTWARE_DOCKER_IMAGE)
+	
 #Build the robot software
-software:
+software: buildenv-container
+	@mkdir -p $(SW_BUILD_DIR)
 	@echo "Building Software..."
+	@docker run -it -v $(SW_BUILD_DIR):/opt/miles/build/sw/ $(SOFTWARE_DOCKER_IMAGE) /usr/local/bin/build_project.sh $(ARCH) $(TOOLCHAIN) build
 
 # Clean build artifacts
 clean:
 	@echo "Cleaning build artifacts..."	
 	@echo "Removing Docker Containers"
-	@docker rm -f $(BUILDROOT_CONTAINER_NAME); \
+	@docker rm -f $(BUILDROOT_CONTAINER_NAME)
+	@docker rm -f $(SOFTWARE_DOCKER_IMAGE)
 
 

--- a/build_project.sh
+++ b/build_project.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+ARCH=$1
+CMAKE_TOOLCHAIN=$2
+# Navigate to the project directory
+cd /opt/miles
+
+# Create build directory if it doesn't exist
+mkdir -p build/sw
+
+# Setups CMake
+# This is where toolchains are passed in
+cmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/toolchain/$ARCH/$CMAKE_TOOLCHAIN.toolchain.cmake -S . -B build/sw
+# If a command-line argument is passed to the script, handle it
+if [ "$3" == "build" ]; then
+  cd build/sw
+  echo "Starting build of robot software"
+  # Run cmake with the toolchain file and then ccmake for interactive configuration
+  make -j$(nproc)
+fi

--- a/docs/design/System-Design.md
+++ b/docs/design/System-Design.md
@@ -46,7 +46,7 @@ across multiple System on Chips (SoCs) and platforms. This abstraction ensures t
 HAL code remain platform-agnostic, facilitating portability and maintainability.
 
 How this is implemented will vary from platform to platform, chip to chip. This layer could call vendor specific libraries
-or driver code. It could also call cross platform libraries that accomplish this task. We allow easy swapping of
+or driver code. It could also call cross platform libraries or OS abstractions that accomplish this task. We allow easy swapping of
 underlying libraries or drivers without affecting the higher-level code; while supporting a wide range of peripherals
 across different platforms.
 
@@ -58,9 +58,12 @@ API for the higher-level code.
 To manage the selection of the appropriate PAL implementation for a given platform, a configuration mechanism is used.
 This can be done through compile-time directives, these can be set using `menuconfig`.
 
-The reccomended implementation is through the use of [WiringX](https://github.com/wiringX/wiringX), a library that
-allows developers to control the GPIO of various platforms with generic and uniform functions. By using wiringX,
-the same code will run on all platforms supported by wiringX, natively.
+The reccomended implementation on the Linux Core is through the use of subsystems provided by the Linux Kernel.
+That way systems such as GPIO, I2C are the same across all Linux SBC's. There is minimal change to the PAL as kernel
+features are used. Any DT-overlays are bundled with PAL for that platform.
+
+While the PAL will for almost all use cases call underyling kernel subsystems, the code will still be portable for other OS'es
+or in the case of no OS.
 
 ## Hardware Abstraction Layer (HAL)
 

--- a/include/common/logger.hpp
+++ b/include/common/logger.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <chrono>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+
+enum class LogLevel
+{
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+};
+
+class Logger
+{
+  public:
+    Logger(LogLevel level = LogLevel::INFO) : logLevel(level), logToConsole(true), logToFile(false)
+    {
+    }
+
+    void setLogLevel(LogLevel level)
+    {
+        logLevel = level;
+    }
+
+    void setLogToConsole(bool enable)
+    {
+        logToConsole = enable;
+    }
+
+    void setLogToFile(const std::string &filename, bool enable)
+    {
+        logToFile = enable;
+        if (enable)
+        {
+            logFile.open(filename, std::ios::out | std::ios::app);
+        }
+        else if (logFile.is_open())
+        {
+            logFile.close();
+        }
+    }
+
+    void log(LogLevel level, const std::string &message)
+    {
+        if (level >= logLevel)
+        {
+            std::string logMessage = formatLogMessage(level, message);
+            std::lock_guard<std::mutex> lock(logMutex);
+            if (logToConsole)
+            {
+                std::cout << logMessage << std::endl;
+            }
+            if (logToFile && logFile.is_open())
+            {
+                logFile << logMessage << std::endl;
+                logFile.flush(); // TODO: may want to buffer this and flush periodically for better
+                                 // performance
+            }
+        }
+    }
+
+    void debug(const std::string &message)
+    {
+        log(LogLevel::DEBUG, message);
+    }
+
+    void info(const std::string &message)
+    {
+        log(LogLevel::INFO, message);
+    }
+
+    void warn(const std::string &message)
+    {
+        log(LogLevel::WARN, message);
+    }
+
+    void error(const std::string &message)
+    {
+        log(LogLevel::ERROR, message);
+    }
+
+  private:
+    LogLevel logLevel;
+    bool logToConsole;
+    bool logToFile;
+    std::ofstream logFile;
+    std::mutex logMutex;
+
+    std::string formatLogMessage(LogLevel level, const std::string &message)
+    {
+        std::ostringstream oss;
+        oss << "[" << getCurrentTime() << "] [" << logLevelToString(level) << "] " << message;
+        return oss.str();
+    }
+
+    std::string getCurrentTime()
+    {
+        auto now = std::chrono::system_clock::now();
+        auto in_time_t = std::chrono::system_clock::to_time_t(now);
+        std::ostringstream oss;
+        oss << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %X");
+        return oss.str();
+    }
+
+    std::string logLevelToString(LogLevel level)
+    {
+        switch (level)
+        {
+        case LogLevel::DEBUG:
+            return "DEBUG";
+        case LogLevel::INFO:
+            return "INFO";
+        case LogLevel::WARN:
+            return "WARN";
+        case LogLevel::ERROR:
+            return "ERROR";
+        default:
+            return "UNKNOWN";
+        }
+    }
+};

--- a/include/common/logger.hpp
+++ b/include/common/logger.hpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <mutex>
 #include <sstream>
+#include <string>
 
 enum class LogLevel
 {
@@ -21,11 +22,17 @@ class Logger
   public:
     Logger(LogLevel level = LogLevel::INFO) : logLevel(level), logToConsole(true), logToFile(false)
     {
+        moduleName = "";
     }
 
     void setLogLevel(LogLevel level)
     {
         logLevel = level;
+    }
+
+    void setModuleName(std::string name)
+    {
+        moduleName = name + ": ";
     }
 
     void setLogToConsole(bool enable)
@@ -87,6 +94,7 @@ class Logger
 
   private:
     LogLevel logLevel;
+    std::string moduleName;
     bool logToConsole;
     bool logToFile;
     std::ofstream logFile;
@@ -95,7 +103,8 @@ class Logger
     std::string formatLogMessage(LogLevel level, const std::string &message)
     {
         std::ostringstream oss;
-        oss << "[" << getCurrentTime() << "] [" << logLevelToString(level) << "] " << message;
+        oss << "[" << getCurrentTime() << "] [" << logLevelToString(level) << "] " << moduleName
+            << message;
         return oss.str();
     }
 

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -3,8 +3,8 @@
 /**
  * Status codes
  */
-enum MilesStatus
+typedef enum mstatus_t
 {
     M_SUCC,
     M_ERROR,
-};
+} mstatus_t;

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/**
+ * Status codes
+ */
+enum MilesStatus
+{
+    M_SUCC,
+    M_ERROR,
+};

--- a/include/pal/spi.h
+++ b/include/pal/spi.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "common/types.h"
+
+class SPIInterface
+{
+  public:
+    // Initialize the SPI device
+    MilesStatus init();
+};

--- a/include/pal/spi.h
+++ b/include/pal/spi.h
@@ -10,6 +10,8 @@ class SPIInterface
 {
   private:
     int fd;
+    uint8_t bus;
+    uint8_t slave;
     uint8_t mode;
     uint8_t bits;
     uint32_t speed;
@@ -21,11 +23,14 @@ class SPIInterface
      * @brief Construct a new SPI object
      *
      * @param deviceName Name of the SPI Device
-     * @param mode SPI mode (e.g., SPI_MODE_0), uses spidev spi modes.
+     * @param mode SPI mode (e.g., SPI_MODE_0), uses spidev spi modes enum regardless of platform.
+     * @param bus SPI bus number
+     * @param slave SPI slave number
      * @param bits Number of bits per word.
      * @param speed Maximum SPI speed in Hz.
      */
-    SPIInterface(const std::string &deviceName, uint8_t mode, uint8_t bits, uint32_t speed);
+    SPIInterface(const std::string &deviceName, uint8_t bus, uint8_t slave, uint8_t mode,
+                 uint8_t bits, uint32_t speed);
 
     /**
      * @brief Cleans up SPI resources

--- a/include/pal/spi.h
+++ b/include/pal/spi.h
@@ -1,10 +1,50 @@
 #pragma once
 
+#include "common/logger.hpp"
 #include "common/types.h"
+#include <cstddef>
+#include <cstdint>
+#include <string>
 
 class SPIInterface
 {
+  private:
+    int fd;
+    uint8_t mode;
+    uint8_t bits;
+    uint32_t speed;
+    std::string deviceName;
+    Logger logger;
+
   public:
-    // Initialize the SPI device
-    MilesStatus init();
+    /**
+     * @brief Construct a new SPI object
+     *
+     * @param deviceName Name of the SPI Device
+     * @param mode SPI mode (e.g., SPI_MODE_0), uses spidev spi modes.
+     * @param bits Number of bits per word.
+     * @param speed Maximum SPI speed in Hz.
+     */
+    SPIInterface(const std::string &deviceName, uint8_t mode, uint8_t bits, uint32_t speed);
+
+    /**
+     * @brief Cleans up SPI resources
+     */
+    ~SPIInterface();
+
+    /**
+     * @brief Initialize the SPI interface
+     * @return mstatus_t status code
+     */
+    mstatus_t init();
+
+    /**
+     * @brief Perform an SPI data transfer.
+     *
+     * @param tx Pointer to the data to be transmitted.
+     * @param rx Pointer to the buffer to store received data.
+     * @param len Length of the data to be transferred. Reflects the size of both tx and rx buffer.
+     * @return mstatus_t status code
+     */
+    mstatus_t spi_transfer(uint8_t *tx, uint8_t *rx, size_t len);
 };

--- a/src/miles.cpp
+++ b/src/miles.cpp
@@ -1,0 +1,5 @@
+int main(int argc, char *argv[])
+{
+
+    return 0;
+}

--- a/src/pal/linux/spi.cpp
+++ b/src/pal/linux/spi.cpp
@@ -1,0 +1,99 @@
+// #ifdef USE_SPIDEV
+
+#include "pal/spi.h"
+#include "common/logger.hpp"
+
+#include <cstdlib>
+#include <fcntl.h>
+#include <linux/spi/spi.h>
+#include <linux/spi/spidev.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define SPI_DEVICE "/dev/spidev0.0"
+#define MODULE_NAME "[SPI]"
+
+SPIInterface::SPIInterface(const std::string &deviceName, uint8_t mode, uint8_t bits,
+                           uint32_t speed)
+{
+    this->deviceName = deviceName;
+    this->mode = mode;
+    this->bits = bits;
+    this->speed = speed;
+    logger.setLogLevel(LogLevel::DEBUG);
+    logger.setLogToFile("spi_spidev.log", true);
+    logger.setModuleName("SPI");
+}
+
+mstatus_t SPIInterface::init()
+{
+    logger.info("Initializing SPI Interface");
+
+    // Opens the device file
+    logger.debug("Opening spidev device file");
+    fd = open(SPI_DEVICE, O_RDWR);
+    if (fd < 0)
+    {
+        logger.error("Unable to open spidev device file");
+        return M_ERROR;
+    }
+
+    // Configure SPI
+    logger.debug("Setting SPI Mode");
+    if (ioctl(fd, SPI_IOC_WR_MODE, &mode) == -1)
+    {
+        logger.error("Unable to set SPI mode");
+        return M_ERROR;
+    }
+
+    logger.debug("Setting SPI bits per word");
+    if (ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &bits) == -1)
+    {
+        logger.error("Unable to set SPI bits per word");
+        return M_ERROR;
+    }
+
+    logger.debug("Setting SPI speed");
+    if (ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) == -1)
+    {
+        logger.error("Unable to set SPI speed");
+        return M_ERROR;
+    }
+
+    return M_SUCC;
+}
+
+mstatus_t SPIInterface::spi_transfer(uint8_t *tx, uint8_t *rx, size_t len)
+{
+    logger.debug("Performing SPI Transfer");
+    // Populates the spi_ioc_transfer struct used by spidev.
+    struct spi_ioc_transfer transfer = {
+        .tx_buf = (unsigned long)tx, // transmit buffer
+        .rx_buf = (unsigned long)rx, // recieve buffer
+        .len = (unsigned int)len,    // Length of the tx and tx buffers
+        .speed_hz = this->speed,     // The clock rate
+        .bits_per_word = this->bits, // Bits per frame
+    };
+
+    // If the operation failed, return an error code
+    if (ioctl(fd, SPI_IOC_MESSAGE(1), &transfer) < 0)
+    {
+        logger.error("Transfer Error");
+        return M_ERROR;
+    }
+
+    return M_SUCC;
+}
+
+SPIInterface::~SPIInterface()
+{
+    // If the spidev device file was opened, close it.
+    if (this->fd >= 0)
+    {
+        close(this->fd);
+    }
+}
+
+// #endif // USE_SPIDEV

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(Miles)
+
+# Set the C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,3 +5,17 @@ project(Miles)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Tests
+option(TEST_SPIDEV "Test PAL SPI Interface using spidev" ON)
+
+# Add include directories
+include_directories(../include)
+include_directories(/opt/riscv64-linux-headers/include)
+
+
+# ========== SPI ==========
+if(TEST_SPIDEV)
+  set(SPI_SOURCES ../src/pal/linux/spi.cpp spi/spi_test.cpp)
+  add_executable(miles_spi_test ${SPI_SOURCES})
+  target_compile_definitions(miles_spi_test PRIVATE USE_SPIDEV)
+endif()

--- a/tests/spi/spi_test.cpp
+++ b/tests/spi/spi_test.cpp
@@ -1,0 +1,84 @@
+#include "pal/spi.h" // Include the header where the SPI class is defined
+#include <iomanip>
+#include <iostream>
+#include <linux/spi/spidev.h>
+#include <vector>
+
+#define SPI_PATH "/dev/spidev0.0"
+
+/**
+ * @brief Test SPI initialization.
+ */
+void test_spi_initialization(SPIInterface *spi_device)
+{
+    mstatus_t ret = spi_device->init();
+    if (ret != M_SUCC)
+        std::cerr << "SPI Initialization Test: Failed" << std::endl;
+
+    std::cout << "SPI Initialization Test: Passed" << std::endl;
+}
+
+/**
+ * @brief Test SPI data transfer.
+ */
+void test_spi_transfer(SPIInterface *spi_device)
+{
+
+    // Example SPI transfer data
+    std::vector<uint8_t> tx = {0xDE, 0xAD, 0xBE, 0xEF};
+    std::vector<uint8_t> rx(tx.size());
+
+    mstatus_t ret = spi_device->spi_transfer(tx.data(), rx.data(), tx.size());
+
+    if (ret != M_SUCC)
+        std::cerr << "SPI Transfer Test: Failed" << std::endl;
+
+    // Print sent data
+    std::cout << "SPI Transfer Test: Sent: ";
+
+    for (auto &byte : tx)
+    {
+        std::cout << "0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(byte)
+                  << " ";
+    }
+    std::cout << std::endl;
+
+    // Print received data
+    std::cout << "SPI Transfer Test: Received: ";
+    for (auto &byte : rx)
+    {
+        std::cout << "0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(byte)
+                  << " ";
+    }
+    std::cout << std::endl;
+    std::cout << "SPI Transfer Test: Passed" << std::endl;
+}
+
+/**
+ * @brief Test error handling in SPI.
+ */
+void test_spi_error_handling()
+{
+    // Try to initialize SPI with an invalid device path
+    SPIInterface spi("Test Device:", 255, 255, SPI_MODE_0, 8, 50000);
+    mstatus_t ret = spi.init();
+    if (ret == M_SUCC)
+        std::cerr << "SPI Error Handling Test: Failed" << std::endl;
+
+    std::cout << "SPI Error Handling Test: Passed " << std::endl;
+}
+
+int main()
+{
+    std::cout << "Starting SPI Tests..." << std::endl;
+
+    SPIInterface spi("Test Device:", 0, 0, SPI_MODE_0, 8, 50000);
+
+    // Run tests
+    test_spi_initialization(&spi);
+    test_spi_transfer(&spi);
+    test_spi_error_handling();
+    std::cout << "SPI Tests Completed." << std::endl;
+
+    return 0;
+}

--- a/toolchain/riscv64/c906fdv-riscv64-unknown-linux-musl.toolchain.cmake
+++ b/toolchain/riscv64/c906fdv-riscv64-unknown-linux-musl.toolchain.cmake
@@ -1,0 +1,31 @@
+add_compile_definitions(BOARD="milkv_duo")
+
+# Define the C compiler and C++ compiler for RISC-V
+SET(CMAKE_SYSTEM_NAME Linux)
+SET(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+set(TOOLCHAIN_PREFIX riscv64-unknown-linux-musl)
+
+# Specify the cross compiler
+SET(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+SET(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+
+# Specify the target environment
+SET(CMAKE_FIND_ROOT_PATH /opt/riscv/${TOOLCHAIN_PREFIX})
+
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
+
+SET(CMAKE_C_FLAGS "-mcpu=c906fdv -march=rv64imafdcv0p7xthead -mcmodel=medany -mabi=lp64d")
+SET(CMAKE_CXX_FLAGS "-mcpu=c906fdv -march=rv64imafdcv0p7xthead -mcmodel=medany -mabi=lp64d")
+
+SET(CMAKE_EXE_LINKER_FLAGS "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64")
+
+# adjust the default behavior of the FIND_XXX() commands:
+# search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
This MR introduces the SPI (Serial Peripheral Interface) interface as part of the Platform Abstraction Layer (PAL) for the hexapod robot project. 

The SPI interface provides a consistent API for SPI communication across different platforms, abstracting the underlying hardware-specific details. 

Because the primary platform is Linux SBC's, The initial implementation uses the spidev subsystem within the kernel to perform SPI communication.

